### PR TITLE
KafkaAppender uses NLog InternalLogger instead of Console.WriteLine

### DIFF
--- a/NLog.Targets.KafkaAppender.Test/nlog.config
+++ b/NLog.Targets.KafkaAppender.Test/nlog.config
@@ -1,20 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      throwConfigExceptions="true"
+      internalLogToConsole="true"
+      internalLogLevel="Warn"
       autoReload="true">
   <extensions>
     <add assembly="NLog.Targets.KafkaAppender"/>
   </extensions>
-  <targets>
+
+  <variable name="KafkaBrokers" value="localhost:9092" />
+  
+  <targets>   
     <target xsi:type="KafkaAppender"
             name="kafka"
-            topic="${callsite:className=true:fileName=false:includeSourcePath=false:methodName=true}"
+            topic="${logger}"
             layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
-            brokers="localhost:9092"
-            debug="false"
-            async="false"
-            >
-
+            brokers="${var:KafkaBrokers}"
+            async="false">
     </target>
   </targets>
   <rules>

--- a/NLog.Targets.KafkaAppender.sln
+++ b/NLog.Targets.KafkaAppender.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31229.75
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.KafkaAppender", "NLog.Targets.KafkaAppender\NLog.Targets.KafkaAppender.csproj", "{5C57956F-6822-4736-8EC5-2DC6125862DB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Targets.KafkaAppender", "NLog.Targets.KafkaAppender\NLog.Targets.KafkaAppender.csproj", "{5C57956F-6822-4736-8EC5-2DC6125862DB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.KafkaAppender.Test", "NLog.Targets.KafkaAppender.Test\NLog.Targets.KafkaAppender.Test.csproj", "{F7982DDA-7357-495C-B4A0-26F4E9362DDF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Targets.KafkaAppender.Test", "NLog.Targets.KafkaAppender.Test\NLog.Targets.KafkaAppender.Test.csproj", "{F7982DDA-7357-495C-B4A0-26F4E9362DDF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B9E27E3D-716A-4719-9925-3C113010C718}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/NLog.Targets.KafkaAppender/Exceptions/BrokerNotFoundException.cs
+++ b/NLog.Targets.KafkaAppender/Exceptions/BrokerNotFoundException.cs
@@ -2,7 +2,7 @@
 
 namespace NLog.Targets.KafkaAppender.Exceptions
 {
-    public class BrokerNotFoundException : Exception
+    public class BrokerNotFoundException : NLogConfigurationException
     {
         public BrokerNotFoundException() { }
 

--- a/NLog.Targets.KafkaAppender/KafkaProducerAbstract.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerAbstract.cs
@@ -19,7 +19,12 @@ namespace NLog.Targets.KafkaAppender
 
         protected IProducer<Null, string> Producer;
 
-        public abstract void Produce(ref string topic, ref string data);
+        public abstract void Produce(string topic, string data);
+
+        public void Flush()
+        {
+            Producer?.Flush();
+        }
 
         public void Dispose()
         {
@@ -34,11 +39,16 @@ namespace NLog.Targets.KafkaAppender
 
             if (disposing)
             {
-                Producer?.Flush();
-                Producer?.Dispose();
+                try
+                {
+                    Producer?.Flush();
+                }
+                finally
+                {
+                    Producer?.Dispose();
+                    _disposed = true;
+                }
             }
-
-            _disposed = true;
         }
     }
 }

--- a/NLog.Targets.KafkaAppender/KafkaProducerAsync.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerAsync.cs
@@ -6,7 +6,7 @@ namespace NLog.Targets.KafkaAppender
     {
         public KafkaProducerAsync(string brokers) : base(brokers) { }
 
-        public override void Produce(ref string topic, ref string data)
+        public override void Produce(string topic, string data)
         {
             Producer.ProduceAsync(topic, new Message<Null, string>
             {

--- a/NLog.Targets.KafkaAppender/KafkaProducerSync.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerSync.cs
@@ -6,7 +6,7 @@ namespace NLog.Targets.KafkaAppender
     {
         public KafkaProducerSync(string brokers) : base(brokers) { }
 
-        public override void Produce(ref string topic, ref string data)
+        public override void Produce(string topic, string data)
         {
             Producer.Produce(topic, new Message<Null, string>
             {

--- a/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
+++ b/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net471;net472;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1
-    </TargetFrameworks>
-    <Version>1.0.9</Version>
+    <TargetFrameworks>netstandard2.0;net45;net46;netcoreapp2.1</TargetFrameworks>
+    <Version>2.0.0</Version>
     <Authors>Hayrullah Cansu</Authors>
     <Company>Hayrullah Cansu</Company>
     <Description>NLog Target/Appender for Apache Kafka</Description>
@@ -17,13 +15,13 @@
     <PackageReleaseNotes>https://github.com/hayrullahcansu/nlog-kafka-target/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageId>NLog.Targets.KafkaAppender</PackageId>
-    <AssemblyVersion>1.0.9.0</AssemblyVersion>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.1" />
-    <PackageReference Include="NLog" Version="4.7.4" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.3" />
+    <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\icon.png" Pack="true" PackagePath="\" />

--- a/README.md
+++ b/README.md
@@ -29,13 +29,10 @@ Install via .NET CLI          dotnet add package NLog.Targets.KafkaAppender
   <targets>
     <target xsi:type="KafkaAppender"
             name="kafka"
-            topic="${callsite:className=true:fileName=false:includeSourcePath=false:methodName=true}"
+            topic="${logger}"
             layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
             brokers="localhost:9092"
-            debug="false"
-            async="false"
-            >
-
+            async="false">
     </target>
   </targets>
   <rules>
@@ -43,18 +40,18 @@ Install via .NET CLI          dotnet add package NLog.Targets.KafkaAppender
   </rules>
 </nlog>
 ```
-| Param Name | Variable Type | Requirement | Description                         | Default                                                                             |
-|------------|---------------|-------------|-------------------------------------|-------------------------------------------------------------------------------------|
-| name       | `:string`     |    yes`*`   | Target's name                       |                                                                                     |
-| topic      | `:layout`     |    yes`*`   | Topic pattern can be layout         | `${callsite:className=true:fileName=false:includeSourcePath=false:methodName=true}` |
-| layout     | `:layout`     |      no     | Layout used to format log messages. | `${longdate}|${level:uppercase=true}|${logger}|${message}`                          |
-| brokers    | `:string`     |    yes`*`   | Kafka brokers with comma-separated  |                                                                                     |
-| debug      | `:boolean`    |      no     | Debugging mode enabled              | `false`                                                                             |
-| async      | `:boolean`    |      no     | Async or sync mode                  | `false`                                                                             |
 
+Parameters:
+
+- **name** : Targets name - `:string` (Required)
+- **topic** : Kafka Topic for publish - `:layout` (Required)
+- **layout** : Layout used to format log messages - `:layout` (Required)
+- **brokers** : Kafka brokers with comma-separated - `:layout` (Required)
+- **async** : Async or sync mode - `:boolean` (Required)
 
 Check documentation about all [`Layout Renderers`](https://nlog-project.org/config/?tab=layout-renderers)
 
+Check [NLog InternalLogger](https://github.com/NLog/NLog/wiki/Internal-Logging) to diagnose issues with Kafka publishing.
 
 ## Usage
 
@@ -70,10 +67,10 @@ namespace NLog.Targets.KafkaAppender.Test
             var logger = NLog.LogManager.GetCurrentClassLogger();
             logger.Error("hello world");
             
-            //topic layout:     ${callsite:className=true:fileName=false:includeSourcePath=false:methodName=true}
+            //topic layout:     ${logger}
             //message layout:   ${longdate}|${level:uppercase=true}|${logger}|${message}
             
-            //topic output:     NLog.Targets.KafkaAppender.Test.Program.Main
+            //topic output:     NLog.Targets.KafkaAppender.Test.Program
             //message output:   2018-12-05 18:27:46.7382|ERROR|NLog.Targets.KafkaAppender.Test.Program|hello world 
             
         }


### PR DESCRIPTION
This aligns the KafkaAppender with other NLog Targets, when needing to diagnose errors.

`${callsite}` has a huge overhead, so instead changed Topic default-value to `${logger}`, that will also partition according to class-names (With help from `NLog.LogManager.GetCurrentClassLogger()`)

Reduced TargetFrameworks to align with `Confluent.Kafka`-nuget-package.

Added explicit flush to increase the chance that flush will happen correctly during shutdown.

Changed Brokers-property from `string` to NLog `Layout`, so it can be loaded from appsettings.json using `${configsetting}`

Always dispose the producer, even if it fails to flush.