### PR TITLE
Fix issue where re-configuring NLog would cause an exception due to disposed producer.

### DIFF
--- a/NLog.Targets.KafkaAppender/KafkaAppender.cs
+++ b/NLog.Targets.KafkaAppender/KafkaAppender.cs
@@ -93,6 +93,7 @@ namespace NLog.Targets.KafkaAppender
             try
             {
                 _producer?.Dispose();
+                _producer = null;
             }
             catch (Exception ex)
             {

--- a/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
+++ b/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>
       netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net471;net472;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1
     </TargetFrameworks>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <Authors>Hayrullah Cansu</Authors>
     <Company>Hayrullah Cansu</Company>
     <Description>NLog Target/Appender for Apache Kafka</Description>
@@ -17,7 +17,7 @@
     <PackageReleaseNotes>https://github.com/hayrullahcansu/nlog-kafka-target/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageId>NLog.Targets.KafkaAppender</PackageId>
-    <AssemblyVersion>1.0.8.0</AssemblyVersion>
+    <AssemblyVersion>1.0.9.0</AssemblyVersion>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
@@ -26,7 +26,7 @@
     <PackageReference Include="NLog" Version="4.7.4" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
When reloading NLog's configuration, NLog seems to be closing the target and then initializing it again. This leaves the KafkaAppender's producer in a disposed state. If we set the producer to null after disposing it, then the InitializeTarget() method will create a new producer.