### PR TITLE
SslCertificateLocation with Layout support, and fatal recovery support

### DIFF
--- a/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigs.cs
+++ b/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigs.cs
@@ -5,6 +5,6 @@ namespace NLog.Targets.KafkaAppender.Configs
     public class KafkaProducerConfigs
     {
         public string SslCertificateLocation{ get; set; }
-        public SecurityProtocol SecurityProtocol { get; set; }
+        public SecurityProtocol? SecurityProtocol { get; set; }
     }
 }

--- a/NLog.Targets.KafkaAppender/KafkaProducerAsync.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerAsync.cs
@@ -1,4 +1,7 @@
-﻿using Confluent.Kafka;
+﻿using System;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using NLog.Common;
 using NLog.Targets.KafkaAppender.Configs;
 
 namespace NLog.Targets.KafkaAppender
@@ -9,10 +12,23 @@ namespace NLog.Targets.KafkaAppender
 
         public override void Produce(string topic, string data)
         {
-            Producer.ProduceAsync(topic, new Message<Null, string>
+            ProduceAsync(topic, data);
+        }
+
+        private async Task ProduceAsync(string topic, string data)
+        {
+            try
             {
-                Value = data
-            });
+                await Producer.ProduceAsync(topic, new Message<Null, string>
+                {
+                    Value = data
+                }).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Error(ex, "KafkaAppender - Exception when sending message to topic={0}", topic);
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
Allow one to use `${configsetting}` to resolve file-path. Followup to #8

Fixed issue with duplicate-code for initializing Kafka-producer. Merged into single method, so recovery-after-fatal-error will also re-create producer with `SslCertificateLocation`