### PR TITLE
adding an NLog variable

### DIFF
--- a/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigs.cs
+++ b/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigs.cs
@@ -6,5 +6,7 @@ namespace NLog.Targets.KafkaAppender.Configs
     {
         public string SslCertificateLocation{ get; set; }
         public SecurityProtocol? SecurityProtocol { get; set; }
+
+        public int? MessageTimeoutMs { get; set; }
     }
 }

--- a/NLog.Targets.KafkaAppender/KafkaAppender.cs
+++ b/NLog.Targets.KafkaAppender/KafkaAppender.cs
@@ -44,6 +44,12 @@ namespace NLog.Targets.KafkaAppender
         /// </summary>
         public bool Async { get; set; } = false;
 
+        /// <summary>
+        /// Local message timeout.This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite.
+        /// </summary>
+        public int? MessageTimeoutMs { get; set; }
+
+
         private KafkaProducerAbstract _producer;
 
         /// <summary>
@@ -63,7 +69,7 @@ namespace NLog.Targets.KafkaAppender
             {
                 InitializeKafkaProducer();
             }
-            
+
             base.InitializeTarget();
         }
 
@@ -85,6 +91,7 @@ namespace NLog.Targets.KafkaAppender
             {
                 SslCertificateLocation = string.IsNullOrEmpty(sslCertificateLocation) ? null : sslCertificateLocation,
                 SecurityProtocol = SecurityProtocol,
+                MessageTimeoutMs = MessageTimeoutMs
             };
 
             try

--- a/NLog.Targets.KafkaAppender/KafkaProducerAbstract.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerAbstract.cs
@@ -15,6 +15,7 @@ namespace NLog.Targets.KafkaAppender
                 BootstrapServers = brokers,
                 SslCertificateLocation = configs?.SslCertificateLocation,
                 SecurityProtocol = configs?.SecurityProtocol,
+                MessageTimeoutMs = configs?.MessageTimeoutMs
             };
 
             Producer = new ProducerBuilder<Null, string>(conf).Build();

--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ Install via .NET CLI          dotnet add package NLog.Targets.KafkaAppender
   </rules>
 </nlog>
 ```
-| Param Name              | Variable Type | Requirement | Description                               | Default                                                                             | Possible values                            |
-|-------------------------|---------------|-------------|-------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------|
-| name                    | `:string`     |    yes`*`   | Target's name                             |                                                                                     |                                            |
-| topic                   | `:layout`     |    yes`*`   | Topic pattern can be layout               | `${logger}`                                                                         |                                            |
-| layout                  | `:layout`     |      no     | Layout used to format log messages.       | `${longdate}|${level:uppercase=true}|${logger}|${message}`                          |                                            |
-| brokers                 | `:string`     |    yes`*`   | Kafka brokers with comma-separated        |                                                                                     |                                            |
-| async                   | `:boolean`    |      no     | Async or sync mode                        | `false`                                                                             |                                            |
-| sslCertificateLocation  | `:string`     |      no     | Path to ssl certificate                   |                                                                                     |                                            |
-| securityProtocol        | `:enum`       |      no     | Protocol used to communicate with brokers | `plaintext`                                                                         | `Plaintext` `Ssl` `SaslPlaintext` `SaslSsl`|
+| Param Name              | Variable Type | Requirement | Description                                                       | Default                                                                             | Possible values                            |
+|-------------------------|---------------|-------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------|
+| name                    | `:string`     |    yes`*`   | Target's name                                                     |                                                                                     |                                            |
+| topic                   | `:layout`     |    yes`*`   | Topic pattern can be layout                                       | `${logger}`                                                                         |                                            |
+| layout                  | `:layout`     |      no     | Layout used to format log messages.                               | `${longdate}|${level:uppercase=true}|${logger}|${message}`                          |                                            |
+| brokers                 | `:string`     |    yes`*`   | Kafka brokers with comma-separated                                |                                                                                     |                                            |
+| async                   | `:boolean`    |      no     | Async or sync mode                                                | `false`                                                                             |                                            |
+| sslCertificateLocation  | `:string`     |      no     | Path to ssl certificate                                           |                                                                                     |                                            |
+| securityProtocol        | `:enum`       |      no     | Protocol used to communicate with brokers                         | `plaintext`                                                                         | `Plaintext` `Ssl` `SaslPlaintext` `SaslSsl`|
+| messageTimeoutMs        | `:int`        |      no     | Limits the time a produced message waits for successful delivery  |                                                                                     |                                            |
 
 
 Check documentation about all [`Layout Renderers`](https://nlog-project.org/config/?tab=layout-renderers)


### PR DESCRIPTION
I've encountered a situation where when Kafka wasn't running and NLog tried to flush a KafkaAppender target, the program got stuck, since Kafka by default waits 300 seconds for an acknowledgement. This way I can adjust the timeout to make sure that doesn't happen.