### PR TITLE
Added exception logging for sync producer

### DIFF
--- a/NLog.Targets.KafkaAppender/KafkaProducerSync.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerSync.cs
@@ -1,5 +1,7 @@
 ﻿using Confluent.Kafka;
+using NLog.Common;
 using NLog.Targets.KafkaAppender.Configs;
+using System;
 
 namespace NLog.Targets.KafkaAppender
 {
@@ -9,10 +11,18 @@ namespace NLog.Targets.KafkaAppender
 
         public override void Produce(string topic, string data)
         {
-            Producer.Produce(topic, new Message<Null, string>
+            try
             {
-                Value = data
-            });
+                Producer.Produce(topic, new Message<Null, string>
+                {
+                    Value = data
+                });
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Error(ex, "KafkaAppender - Exception when sending message to topic={0}", topic);
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
KafkaProducerAsync logs errors to internal logger in case of error when produces a message. The KafkaProducerSync doesn't log any messages in case of error.
This is small fix of this issue