### PR TITLE
Updated to NLog v4.7.15 and Confluent.Kafka v1.8.2

### DIFF
--- a/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
+++ b/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
     <Version>2.1.3</Version>
     <Authors>Hayrullah Cansu</Authors>
     <Company>Hayrullah Cansu</Company>
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.3" />
-    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
+    <PackageReference Include="NLog" Version="4.7.15" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\icon.png" Pack="true" PackagePath="\" />

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ nlog appender for kafka which provides the custom topics pattern and partitions
 
 ## Supported frameworks 
 ```
-.NET Framework 4.5, 4.6 & 4.7
-ASP.NET 4.5+ (NLog.Web package)
-ASP.NET Core (NLog.Web.AspNetCore package)
-.NET Core (NLog.Extensions.Logging package)
-.NET Standard 2.x+ - NLog 4.5
+- .NET 5, 6 and 7
+- .NET Core 2 and 3
+- .NET Standard 2.0+
+- .NET Framework 4.5 - 4.8
 ```
 
 ## Getting Started


### PR DESCRIPTION
Removed now obsolete `netcoreapp2.1`, since `netstandard2.0` will work just fine.

- NLog v4.7.15 was released - 26/03/2022
- Confluent.Kafka v1.8.2 was released - 19/10/2021