### PR TITLE
Updated to Confluent.Kafka ver. 2.4.0 with LibSsl ver. 3

### DIFF
--- a/NLog.Targets.KafkaAppender.Test/NLog.Targets.KafkaAppender.Test.csproj
+++ b/NLog.Targets.KafkaAppender.Test/NLog.Targets.KafkaAppender.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NLog.Targets.KafkaAppender.Test/nlog.config
+++ b/NLog.Targets.KafkaAppender.Test/nlog.config
@@ -11,19 +11,14 @@
 
   <variable name="KafkaBrokers" value="localhost:9092" />
   
-  <targets>   
+  <targets>
     <target xsi:type="KafkaAppender"
             name="kafka"
             topic="${logger}"
             layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
             brokers="${var:KafkaBrokers}"
-            async="false"
-	          sslCertificateLocation=""
-            SslCaLocation=""
-            SslKeyLocation=""
-            SslKeyPassword=""
-            securityProtocol="plaintext">
-
+            async="false">
+      <setting key="client.id" value="NLog_${machinename}" /> <!-- Multiple allowed -->
     </target>
   </targets>
   <rules>

--- a/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigSetting.cs
+++ b/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigSetting.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+using NLog.Config;
+using NLog.Layouts;
+
+namespace NLog.Targets.KafkaAppender.Configs
+{
+    /// <summary>
+    /// Kafka Producer Setting (Key-Value Pair). Ex. client.id = NLog_${machinename}
+    /// </summary>
+    /// <remarks>
+    /// See also <see href="https://kafka.apache.org/documentation/#producerconfigs" />
+    /// </remarks>
+    [NLogConfigurationItem]
+    public class KafkaProducerConfigSetting
+    {
+        public string Key { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Name { get => Key; set => Key = value; }
+        public Layout Value { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Layout Layout { get => Value; set => Value = value; }
+    }
+}

--- a/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigs.cs
+++ b/NLog.Targets.KafkaAppender/Configs/KafkaProducerConfigs.cs
@@ -1,27 +1,30 @@
-﻿using Confluent.Kafka;
+﻿using System.Collections.Generic;
+using Confluent.Kafka;
 
 namespace NLog.Targets.KafkaAppender.Configs
 {
     public class KafkaProducerConfigs
     {
+        /// <inheritdoc cref="ClientConfig.ClientId"/>
         public string ClientId { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SslCertificateLocation"/>
         public string SslCertificateLocation { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SslCaLocation"/>
         public string SslCaLocation { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SslKeyLocation"/>
         public string SslKeyLocation { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SslKeyPassword"/>
         public string SslKeyPassword { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SecurityProtocol"/>
         public SecurityProtocol? SecurityProtocol { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.MessageTimeoutMs"/>
         public int? MessageTimeoutMs { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SaslMechanism"/>
         public SaslMechanism? SaslMechanism { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SaslUsername"/>
         public string SaslUsername { get; set; }
-
+        /// <inheritdoc cref="ClientConfig.SaslPassword"/>
         public string SaslPassword { get; set; }
+        public Dictionary<string, string> Settings { get; set; }
     }
 }

--- a/NLog.Targets.KafkaAppender/KafkaProducerAbstract.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerAbstract.cs
@@ -11,25 +11,37 @@ namespace NLog.Targets.KafkaAppender
 
         protected KafkaProducerAbstract(string brokers, KafkaProducerConfigs configs = null)
         {
-            var conf = new ProducerConfig
+            var producerConfig = configs?.Settings?.Count > 0 ? new ProducerConfig(configs.Settings) : new ProducerConfig();
+            if (!string.IsNullOrEmpty(brokers))
             {
-                BootstrapServers = brokers,
-                SslCertificateLocation = configs?.SslCertificateLocation,
-                SslCaLocation = configs?.SslCaLocation,
-                SslKeyLocation = configs?.SslKeyLocation,
-                SslKeyPassword = configs?.SslKeyPassword,
-                SecurityProtocol = configs?.SecurityProtocol,
-                MessageTimeoutMs = configs?.MessageTimeoutMs,
-                SaslUsername = configs?.SaslUsername,
-                SaslPassword = configs?.SaslPassword,
-                SaslMechanism = configs?.SaslMechanism
-            };
-            if (!string.IsNullOrEmpty(configs?.ClientId))
-            {
-                conf.ClientId = configs.ClientId;
+                producerConfig.BootstrapServers = brokers;
             }
 
-            Producer = new ProducerBuilder<Null, string>(conf)
+            if (configs != null)
+            {
+                if (configs.SaslMechanism.HasValue)
+                    producerConfig.SaslMechanism = configs.SaslMechanism;
+                if (configs.SecurityProtocol.HasValue)
+                    producerConfig.SecurityProtocol = configs.SecurityProtocol;
+                if (configs.SslCertificateLocation != null)
+                    producerConfig.SslCertificateLocation = configs.SslCertificateLocation;
+                if (configs.SslCaLocation != null)
+                    producerConfig.SslCaLocation = configs.SslCaLocation;
+                if (configs.SslKeyLocation != null)
+                    producerConfig.SslKeyLocation = configs.SslKeyLocation;
+                if (configs.SslKeyPassword != null)
+                    producerConfig.SslKeyPassword = configs.SslKeyPassword;
+                if (configs.MessageTimeoutMs.HasValue)
+                    producerConfig.MessageTimeoutMs = configs.MessageTimeoutMs;
+                if (configs.SaslUsername != null)
+                    producerConfig.SaslUsername = configs.SaslUsername;
+                if (configs.SaslPassword != null)
+                    producerConfig.SaslPassword = configs.SaslPassword;
+                if (!string.IsNullOrEmpty(configs.ClientId))
+                    producerConfig.ClientId = configs.ClientId;
+            }
+
+            Producer = new ProducerBuilder<Null, string>(producerConfig)
                 .SetErrorHandler((producer, error) =>
                 {
                     InternalLogger.Error("KafkaAppender - {0}Error when sending message to topic. ErrorCode={1}, Reason={2}", error.IsFatal ? "Fatal " : "", error.Code, error.Reason);

--- a/NLog.Targets.KafkaAppender/KafkaProducerAsync.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerAsync.cs
@@ -6,16 +6,23 @@ namespace NLog.Targets.KafkaAppender
 {
     public class KafkaProducerAsync : KafkaProducerAbstract
     {
+        private TopicPartition _lastTopicPartition;
+
         public KafkaProducerAsync(string brokers, KafkaProducerConfigs configs = null) : base(brokers, configs) { }
 
         public override void Produce(string topic, string data)
         {
-            ProduceAsync(topic, data);
+            var topicPartition = _lastTopicPartition;
+            if (!string.Equals(topic, topicPartition?.Topic, System.StringComparison.Ordinal))
+            {
+                _lastTopicPartition = topicPartition = new TopicPartition(topic, Partition.Any);
+            }
+            ProduceAsync(topicPartition, data);
         }
 
-        private Task ProduceAsync(string topic, string data)
+        private Task ProduceAsync(TopicPartition topicPartition, string data)
         {
-            return Producer.ProduceAsync(topic, new Message<Null, string>
+            return Producer.ProduceAsync(topicPartition, new Message<Null, string>
             {
                 Value = data
             });

--- a/NLog.Targets.KafkaAppender/KafkaProducerSync.cs
+++ b/NLog.Targets.KafkaAppender/KafkaProducerSync.cs
@@ -5,11 +5,19 @@ namespace NLog.Targets.KafkaAppender
 {
     public class KafkaProducerSync : KafkaProducerAbstract
     {
+        private TopicPartition _lastTopicPartition;
+
         public KafkaProducerSync(string brokers, KafkaProducerConfigs configs = null) : base(brokers, configs) { }
 
         public override void Produce(string topic, string data)
         {
-            Producer.Produce(topic, new Message<Null, string>
+            var topicPartition = _lastTopicPartition;
+            if (!string.Equals(topic, topicPartition?.Topic, System.StringComparison.Ordinal))
+            {
+                _lastTopicPartition = topicPartition = new TopicPartition(topic, Partition.Any);
+            }
+
+            Producer.Produce(topicPartition, new Message<Null, string>
             {
                 Value = data
             });

--- a/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
+++ b/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Version>2.1.6</Version>
     <Authors>Hayrullah Cansu</Authors>
     <Company>Hayrullah Cansu</Company>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
+    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
     <PackageReference Include="NLog" Version="4.7.15" />
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nlog-kafka-target
-nlog appender for kafka which provides the custom topics pattern and partitions
+NLog appender for kafka which provides the custom topics pattern and partitions
 
 ![Nuget](https://img.shields.io/nuget/dt/NLog.Targets.KafkaAppender)
 [![GitHub issues](https://img.shields.io/github/issues/hayrullahcansu/nlog-kafka-target)](https://github.com/hayrullahcansu/nlog-kafka-target/issues)
@@ -13,7 +13,7 @@ nlog appender for kafka which provides the custom topics pattern and partitions
 - .NET 5, 6, 7 and 8
 - .NET Core 2 and 3
 - .NET Standard 2.0+
-- .NET Framework 4.5 - 4.8
+- .NET Framework 4.6.2 - 4.8.1
 ```
 
 ## Getting Started
@@ -38,10 +38,8 @@ Install via .NET CLI          dotnet add package NLog.Targets.KafkaAppender
             topic="${callsite:className=true:fileName=false:includeSourcePath=false:methodName=true}"
             layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
             brokers="localhost:9092"
-            clientId="${hostname}"
-            async="false"
-            >
-
+            async="false">
+        <setting key="client.id" value="NLog_${machinename}" /> <!-- Multiple allowed -->
     </target>
   </targets>
   <rules>
@@ -55,7 +53,6 @@ Install via .NET CLI          dotnet add package NLog.Targets.KafkaAppender
 | topic                   | `:layout`     |    yes`*`   | Topic pattern can be layout                                               | `${logger}`                                                |
 | layout                  | `:layout`     |      no     | Layout used to format log messages.                                       | `${longdate}|${level:uppercase=true}|${logger}|${message}` |
 | brokers                 | `:string`     |    yes`*`   | Kafka brokers with comma-separated                                        |                                                            |
-| clientId                | `:layout`     |      no     | Producer Client Identification. Ex. `${hostname}`                         |                                                            |
 | async                   | `:boolean`    |      no     | Async or sync mode                                                        | `false`                                                    |
 | securityProtocol        | `:enum`       |      no     | Broker Security Protocol. Ex. `Plaintext`,`Ssl`,`SaslPlaintext`,`SaslSsl` | `plaintext`                                                |
 | SaslMechanism           | `:enum`       |      no     | SASL Mechanism. Ex. `Gssapi`,`Plain`,`ScramSha256`,`ScramSha512`,`OAuthBearer` |`Gssapi` |
@@ -66,6 +63,7 @@ Install via .NET CLI          dotnet add package NLog.Targets.KafkaAppender
 | SaslUsername            | `:string`     |      no     | Simple Authentication and Security Layer (SASL) Username                  | |
 | SaslPassword            | `:string`     |      no     | Simple Authentication and Security Layer (SASL) Password                  | |
 | messageTimeoutMs        | `:int`        |      no     | Limits the time a produced message waits for successful delivery          | |
+| setting                 | key + value   |      no     | [Kafka Producer Config](https://kafka.apache.org/documentation/#producerconfigs) | |
 
 Check documentation about all [`Layout Renderers`](https://nlog-project.org/config/?tab=layout-renderers)
 
@@ -90,9 +88,8 @@ Scenario: using Confluent Cloud http://developer.confluent.io/get-started/dotnet
             securityProtocol="SaslPlaintext"
             SaslMechanism="Plain"
             SaslUsername="API-Key"
-            SaslPassword="API-secret"
-            >
-
+            SaslPassword="API-secret">
+        <setting key="client.id" value="NLog_${machinename}" /> <!-- Multiple allowed -->
     </target>
   </targets>
   <rules>


### PR DESCRIPTION
Trying to resolve #16. Now you can provide arbitrary Kafka Producer settings like this:
```xml
    <target xsi:type="KafkaAppender"
            name="kafka"
            topic="${logger}"
            layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
            brokers="localhost:9092"
            async="false">
        <setting key="client.id" value="NLog_${machinename}" /> <!-- Multiple allowed -->
    </target>
```
See also: https://kafka.apache.org/documentation/#producerconfigs