### PR TITLE
Update Confluent.Kafka to 2.8

### DIFF
--- a/NLog.Targets.KafkaAppender.Test/nlog.config
+++ b/NLog.Targets.KafkaAppender.Test/nlog.config
@@ -18,7 +18,7 @@
             layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
             brokers="${var:KafkaBrokers}"
             async="false">
-      <setting key="client.id" value="NLog_${machinename}" /><!-- Multiple allowed -->
+      <setting key="client.id" value="NLog_${machinename}" /> <!-- Multiple allowed -->
     </target>
   </targets>
   <rules>

--- a/NLog.Targets.KafkaAppender.Test/nlog.config
+++ b/NLog.Targets.KafkaAppender.Test/nlog.config
@@ -10,7 +10,7 @@
   </extensions>
 
   <variable name="KafkaBrokers" value="localhost:9092" />
-
+  
   <targets>
     <target xsi:type="KafkaAppender"
             name="kafka"

--- a/NLog.Targets.KafkaAppender.Test/nlog.config
+++ b/NLog.Targets.KafkaAppender.Test/nlog.config
@@ -18,7 +18,7 @@
             layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
             brokers="${var:KafkaBrokers}"
             async="false">
-      <setting key="client.id" value="NLog_${machinename}" /> <!-- Multiple allowed -->
+      <setting key="client.id" value="NLog_${machinename}" />
     </target>
   </targets>
   <rules>

--- a/NLog.Targets.KafkaAppender.Test/nlog.config
+++ b/NLog.Targets.KafkaAppender.Test/nlog.config
@@ -10,7 +10,7 @@
   </extensions>
 
   <variable name="KafkaBrokers" value="localhost:9092" />
-  
+
   <targets>
     <target xsi:type="KafkaAppender"
             name="kafka"
@@ -18,7 +18,7 @@
             layout="${longdate}|${level:uppercase=true}|${logger}|${message}"
             brokers="${var:KafkaBrokers}"
             async="false">
-      <setting key="client.id" value="NLog_${machinename}" />
+      <setting key="client.id" value="NLog_${machinename}" /><!-- Multiple allowed -->
     </target>
   </targets>
   <rules>

--- a/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
+++ b/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.12.0" />
     <PackageReference Include="NLog" Version="4.7.15" />
   </ItemGroup>
   <ItemGroup>

--- a/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
+++ b/NLog.Targets.KafkaAppender/NLog.Targets.KafkaAppender.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.12.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.8.0" />
     <PackageReference Include="NLog" Version="4.7.15" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This update upgrades the Confluent.Kafka dependency from 2.5 to 2.8 to ensure compatibility with recent Kafka client features and avoid type conversion issues when configuring SASL credentials dynamically via NLog.

Resolves #18